### PR TITLE
Fixes/qemu linenum funcs

### DIFF
--- a/src/kpatch_gensrc.c
+++ b/src/kpatch_gensrc.c
@@ -1488,13 +1488,13 @@ int main(int argc, char **argv)
 			if (k >= 2)
 				kpfatal("only 2 input files must be specified\n");
 			if ((err = read_file(&infile[k], optarg)))
-				kpfatal("Can't read input file: %s\n", strerror(err));
+				kpfatal("Can't read input file '%s': %s\n", optarg, strerror(err));
 			infile[k].id = k;
 			k++;
 			break;
 		case 'o':
 			if ((err = create_file(&outfile, optarg)))
-				kpfatal("Can't open output file: %s\n", strerror(err));
+				kpfatal("Can't open output file '%s': %s\n", optarg, strerror(err));
 			break;
 		case 'O':
 			if (!strcmp(optarg, "rhel5")) os = OS_RHEL5;

--- a/src/kpatch_gensrc.c
+++ b/src/kpatch_gensrc.c
@@ -411,12 +411,20 @@ static struct {
 	{ "warn_slowpath_null", "esi" },
 	{ "warn_slowpath_fmt", "esi" },
 	{ "warn_slowpath_fmt_taint", "esi" },
+
+	{ "object_dynamic_cast_assert@PLT", "ecx" },
+	{ "object_class_dynamic_cast_assert@PLT", "ecx" },
+	{ "error_setg_internal@PLT", "edx" },
+	{ "error_setg_errno_internal@PLT", "edx" },
+	{ "g_assertion_message_expr@PLT", "edx" },
+	{ "__assert_fail@PLT", "edx" },
+	{ "__assert_fail@PLT", "dx" },
 };
 
 static inline int get_mov_const_reg(const char *s, char *regname)
 {
 	/* Extract register name ignoring the line number. */
-	return sscanf(s, " movl $%*i, %%%31[a-zA-Z0-9]", regname);
+	return sscanf(s, " mov%*c $%*i, %%%31[a-zA-Z0-9]", regname);
 }
 
 /*

--- a/src/kpatch_gensrc.c
+++ b/src/kpatch_gensrc.c
@@ -441,15 +441,14 @@ static int match_warn_once(struct cblock *b0, int *p0, struct cblock *b1, int *p
 		return 0;
 
 	/*
-	 * The distance between line number saving instruction and the call to
-	 * warn_slowpath* function can get quite big (e.g.  up to 14 lines) but
-	 * number of such cases is small.  For vmlinux images, only about 1% of
-	 * warn_slowpath* calls have this distance larger than 6.  The longer
-	 * the parsing distance here, the more chances to get caught by
-	 * compilers "optimizations" (e.g.  jmp's in/out that are not checked
-	 * here), so it's better to keep this limit not too big.
+	 * Just in case, it's better to keep the search distance as small as
+	 * possible.  Usually, call to warn_slowpath* is within 6 next lines
+	 * (~99% of warnings in vmlinux), but in some functions that are better
+	 * left unpatched there are warnings with quite a large number of
+	 * arguments (e.g. tcp_recvmsg on 2.6.32 kernels has 15 lines between
+	 * saving line-number and calling warn_slowpath_fmt).
 	 */
-	for (i = 0; i < 7; i++, i0++, i1++) {
+	for (i = 0; i < 15; i++, i0++, i1++) {
 		if (i0 >= b0->end || i1 >= b1->end)
 			return 0;
 		s0 = cline(b0->f, i0); s1 = cline(b1->f, i1);


### PR DESCRIPTION
Add detection for QEMU's linenum arguments in function calls such as __assert_fail and so on.