### PR TITLE
Fix storage_lookup_patches return code in case process already termin…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,12 +36,12 @@ kpatch_make: kpatch_make.o
 LIBUNWIND_LIBS := $(shell pkg-config --libs libunwind libunwind-ptrace)
 
 
-libcare-ctl: kpatch_user.o kpatch_storage.o kpatch_patch.c kpatch_elf.o kpatch_ptrace.o kpatch_coro.o 
+libcare-ctl: kpatch_user.o kpatch_storage.o kpatch_patch.o kpatch_elf.o kpatch_ptrace.o kpatch_coro.o
 libcare-ctl: kpatch_process.o kpatch_common.o rbtree.o kpatch_log.o
 libcare-ctl: LDLIBS += -lelf -lrt $(LIBUNWIND_LIBS)
 
-libcare-stresstest: kpatch_user-stresstest.o kpatch_storage.o kpatch_patch.c kpatch_elf.o kpatch_ptrace.o kpatch_coro.o
-libcare-stresstest: kpatch_process.o kpatch_common.o rbtree.o kpatch_log.o
+libcare-stresstest: kpatch_user-stresstest.o kpatch_log-stresstest.o kpatch_storage.o kpatch_patch.o kpatch_elf.o kpatch_ptrace.o kpatch_coro.o
+libcare-stresstest: kpatch_process.o kpatch_common.o rbtree.o
 libcare-stresstest: LDLIBS += -lelf -lrt $(LIBUNWIND_LIBS)
 
 libcare-client: libcare-client.o

--- a/src/kpatch_log.c
+++ b/src/kpatch_log.c
@@ -5,8 +5,10 @@
 #include <errno.h>
 
 #include "kpatch_log.h"
+
 #ifdef STRESS_TEST
 #include "kpatch_user.h"
+extern int parent_pid;
 #endif
 
 int log_level = LOG_INFO;
@@ -64,6 +66,10 @@ void kpfatal(const char *fmt, ...)
 	__valog(LOG_ERR, "FATAL! ", fmt, va);
 	va_end(va);
 
+#ifdef STRESS_TEST
+	if (parent_pid >= 0)
+		stress_test_notify_parent();
+#endif
 	exit(1);
 }
 

--- a/src/kpatch_log.h
+++ b/src/kpatch_log.h
@@ -33,4 +33,7 @@ void _kplogerror(const char *filename, int line, const char *fmt, ...)
 #define LOG_DEBUG	3
 #define LOG_TRACE	5
 
+int log_file_init(char *fname);
+void log_file_free();
+
 #endif

--- a/src/kpatch_patch.c
+++ b/src/kpatch_patch.c
@@ -437,7 +437,7 @@ object_unapply_old_patch(struct object_file *o)
 		return 1;
 	}
 
-	printf("%s: replacing patch level %d with level %d\n",
+	kpinfo("%s: replacing patch level %d with level %d\n",
 	       o->name,
 	       kpatch_applied->user_level,
 	       kpatch_storage->user_level);
@@ -565,12 +565,12 @@ out_free:
 
 out:
 	if (ret < 0) {
-		printf("Failed to apply patch '%s'\n", storage->path);
+		kpinfo("Failed to apply patch '%s'\n", storage->path);
 		kperr("Failed to apply patch '%s'\n", storage->path);
 	} else if (ret == 0)
-		printf("No patch(es) applicable to PID '%d' have been found\n", pid);
+		kpinfo("No patch(es) applicable to PID '%d' have been found\n", pid);
 	else {
-		printf("%d patch hunk(s) have been successfully applied to PID '%d'\n", ret, pid);
+		kpinfo("%d patch hunk(s) have been successfully applied to PID '%d'\n", ret, pid);
 		ret = 0;
 	}
 
@@ -750,11 +750,11 @@ out:
 	kpatch_process_free(proc);
 
 	if (ret < 0)
-		printf("Failed to cancel patches for %d\n", pid);
+		kpinfo("Failed to cancel patches for %d\n", pid);
 	else if (ret == 0)
-		printf("No patch(es) cancellable from PID '%d' were found\n", pid);
+		kpinfo("No patch(es) cancellable from PID '%d' were found\n", pid);
 	else
-		printf("%d patch hunk(s) were successfully cancelled from PID '%d'\n", ret, pid);
+		kpinfo("%d patch hunk(s) were successfully cancelled from PID '%d'\n", ret, pid);
 
 	return ret;
 }

--- a/src/kpatch_process.c
+++ b/src/kpatch_process.c
@@ -746,9 +746,9 @@ process_print_cmdline(kpatch_process_t *proc)
 
 		for (i = 0; i < rv; i++) {
 			if (buf[i] != '\n' && isprint(buf[i]))
-				putchar(buf[i]);
+				kpinfo("%c", buf[i]);
 			else
-				printf("\\x%02x", (unsigned char)buf[i]);
+				kpinfo("\\x%02x", (unsigned char)buf[i]);
 		}
 	}
 
@@ -860,9 +860,9 @@ kpatch_process_kickstart_execve_wrapper(kpatch_process_t *proc)
 	if (ret < 0)
 		return -1;
 
-	printf("kpatch_ctl real cmdline=\"");
+	kpinfo("kpatch_ctl real cmdline=\"");
 	process_print_cmdline(proc);
-	printf("\"\n");
+	kpinfo("\"\n");
 
 	return 0;
 }
@@ -1137,11 +1137,11 @@ out_err:
 void
 kpatch_process_print_short(kpatch_process_t *proc)
 {
-	printf("kpatch_ctl targeting pid %d\n", proc->pid);
+	kpinfo("kpatch_ctl targeting pid %d\n", proc->pid);
 	if (proc->send_fd == -1) {
-		printf("kpatch_ctl cmdline=\"");
+		kpinfo("kpatch_ctl cmdline=\"");
 		process_print_cmdline(proc);
-		printf("\"\n");
+		kpinfo("\"\n");
 	}
 }
 

--- a/src/kpatch_storage.c
+++ b/src/kpatch_storage.c
@@ -398,7 +398,7 @@ int storage_lookup_patches(kpatch_storage_t *storage, kpatch_process_t *proc)
 	struct kp_file *pkpfile;
 	struct object_file *o;
 	const char *bid;
-	int found = 0, ret;
+	int found = -1, ret;
 
 	list_for_each_entry(o, &proc->objs, list) {
 		if (!o->is_elf || is_kernel_object_name(o->name))
@@ -410,6 +410,8 @@ int storage_lookup_patches(kpatch_storage_t *storage, kpatch_process_t *proc)
 			       o->name);
 			continue;
 		}
+		if (found < 0)
+			found = 0;
 
 		ret = storage_load_patch(storage, bid, &pkpfile);
 		if (ret == PATCH_OPEN_ERROR) {

--- a/src/kpatch_user.h
+++ b/src/kpatch_user.h
@@ -7,5 +7,6 @@
 
 int cmd_patch_user(int argc, char *argv[]);
 int cmd_unpatch_user(int argc, char *argv[]);
+void stress_test_notify_parent();
 
 #endif


### PR DESCRIPTION
Sometimes during stress tests buildids can't be retrieved because process already terminated. 
In this case "No patch(es) applicable to PID '%d' have been found\n" was printed, which is considered error by test scripts.