### PR TITLE
kpatch_storage: put an end to description string loaded

### DIFF
--- a/src/kpatch_storage.c
+++ b/src/kpatch_storage.c
@@ -377,8 +377,10 @@ char *storage_get_description(kpatch_storage_t *storage,
 		if (rv == -1)
 			goto err_free;
 
-		if (rv == 0)
+		if (rv == 0) {
+			desc[sz] = '\0';
 			break;
+		}
 
 		sz += rv;
 	}


### PR DESCRIPTION
Description string should be ended up with a '\0'.