### PR TITLE
Fix README files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 LibCare -- Patch Userspace Code on Live Processes
 =================================================
 
+.. image:: https://travis-ci.org/cloudlinux/libcare.svg?branch=master
+    :target: https://travis-ci.org/cloudlinux/libcare
+
 Welcome to LibCare --- Live Patch Updates for Userspace Processes and Libraries.
 
 LibCare delivers live patches to any of your Linux executables or libraries at

--- a/samples/ghost/README.rst
+++ b/samples/ghost/README.rst
@@ -32,6 +32,17 @@ Now, from inside the container let's install vulnerable version of glibc:
                 glibc-headers-2.17-55.el7 glibc-common-2.17-55.el7
         ...
 
+Also we have to downgrade elfutils since newer versions of ``eu-unstrip``
+fail to work with glibc utilities:
+
+.. code:: console
+
+        [root@... /]# yum downgrade -y --enablerepo=C7.0.1406-base \
+                elfutils-devel-0.158-3.el7.x86_64 elfutils-0.158-3.el7.x86_64 \
+                elfutils-libs-0.158-3.el7.x86_64 elfutils-libelf-0.158-3.el7.x86_64 \
+                elfutils-libelf-devel-0.158-3.el7.x86_64
+        ...
+
 Build the ``libcare`` tools:
 
 .. code:: console


### PR DESCRIPTION
Fixes issue #48.

Current `pkgbuild` script is not compatible with the latest `elfutils` package from CentOS 7, so in provided docker container it is necessary to perform an additional step (downgrade it to version from CentOS 7.0):
```
yum downgrade -y --enablerepo=C7.0.1406-base elfutils-devel-0.158-3.el7.x86_64 elfutils-0.158-3.el7.x86_64 elfutils-libs-0.158-3.el7.x86_64 elfutils-libelf-0.158-3.el7.x86_64 elfutils-libelf-devel-0.158-3.el7.x86_64
```
Also added Travis CI status image to main README file.