### PR TITLE
kpatch_patch: suppress print_address_closest_func() when the log level is not debug

### DIFF
--- a/src/kpatch_patch.c
+++ b/src/kpatch_patch.c
@@ -92,7 +92,8 @@ object_patch_verify_safety_single(struct object_file *o,
 		kpfatal("unknown direction");
 
 	do {
-		print_address_closest_func(LOG_INFO, o, cur, direction == ACTION_UNAPPLY_PATCH);
+		if (log_level >= LOG_DEBUG)
+			print_address_closest_func(LOG_DEBUG, o, cur, direction == ACTION_UNAPPLY_PATCH);
 
 		unw_get_reg(cur, UNW_REG_IP, &ip);
 


### PR DESCRIPTION
Stack unwind functions from libunwind sometimes can be very time
consuming. If not necessary, try use these functions as less as
possible.

Signed-off-by: Luo Yifan <luoyifan_yewu@cmss.chinamobile.com>